### PR TITLE
Re-license and copyright notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 MIT License
 
+Copyright (c) 2023 Digital Logic Sim Community Contributors
 Copyright (c) 2020 Sebastian Lague
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ This is based on the original Digital Logic Sim by [SebLague][2] at [SebLague/Di
 ![Simulation Screenshot][image-1]
 
 ## Similar projects:
-- [SebLague/Digital-Logic-Sim][3]
-- [UkrainianBanderasCat/Digital-Logic-Sim-2][5]
+- [SebLague/Digital-Logic-Sim][5]
+- [UkrainianBanderasCat/Digital-Logic-Sim-2][6]
+- [logisim-evolution/logisim-evolution][7]
 
 ## Contributors
 
@@ -42,10 +43,22 @@ This is based on the original Digital Logic Sim by [SebLague][2] at [SebLague/Di
   <img src="https://contrib.rocks/image?repo=DigitalLogicSimCommunity/Digital-Logic-Sim-CE" />
 </a>
 
+## License
+
+- This is an independent fork of the original Digital Logic Sim by [SebLague][8] at [SebLague/Digital-Logic-Sim][9] since its commit [70be9af][10] distributed with an [MIT License][11].
+- This is free software licensed under the [MIT License][12].
+
 [1]:	https://github.com/DigitalLogicSimCommunity/Digital-Logic-Sim-CE/releases/latest
 [2]:	https://github.com/SebLague
 [3]:	https://github.com/SebLague/Digital-Logic-Sim
 [4]:	https://www.youtube.com/watch?v=QZwneRb-zqA
-[5]:	https://github.com/UkrainianBanderasCat/Digital-Logic-Sim2
+[5]:	https://github.com/SebLague/Digital-Logic-Sim
+[6]:	https://github.com/UkrainianBanderasCat/Digital-Logic-Sim2
+[7]:	https://github.com/logisim-evolution/logisim-evolution
+[8]:	https://github.com/SebLague
+[9]:	https://github.com/SebLague/Digital-Logic-Sim
+[10]:	https://github.com/SebLague/Digital-Logic-Sim/commit/70be9af9812b61e1bf3f7b4ec3c38d109fb311c7
+[11]:	https://github.com/SebLague/Digital-Logic-Sim/blob/70be9af9812b61e1bf3f7b4ec3c38d109fb311c7/LICENSE
+[12]:	LICENSE
 
 [image-1]:	https://raw.githubusercontent.com/DigitalLogicSimCommunity/.github/main/imgs/ALU.png


### PR DESCRIPTION
Sebastian changed the license of the original Digital Logic Sim project [3 days ago](https://github.com/SebLague/Digital-Logic-Sim/commit/7836302f0517f11d1b61e0c0c5c105ae51b53a80) with its 1.0 release. I thought it would be a good idea to state this fork was made from a [commit](https://github.com/SebLague/Digital-Logic-Sim/commit/70be9af9812b61e1bf3f7b4ec3c38d109fb311c7) where an MIT License governed the mainstream repo. Hence, this project can be re-licensed with the same License with an added copyright notice from the organization’s contributors, as mentioned [here](https://opensource.stackexchange.com/questions/4439/how-to-deal-with-licences-after-forking-a-project) and [here](https://opensource.stackexchange.com/questions/6945/if-i-change-the-license-of-my-project-can-someone-use-the-old-license-by-naviga).

Furthermore, I think we should include with the release 'binaries' the original LICENSE file to be fully compliant. 

I'm fairly new to license stuff. So, any comments before merging would be appreciated.