### PR TITLE
Fix FPS Limit and VSync Targeting Issues

### DIFF
--- a/Assets/Scripts/Graphics/TargetFrameRate.cs
+++ b/Assets/Scripts/Graphics/TargetFrameRate.cs
@@ -5,12 +5,12 @@ using UnityEngine;
 using TMPro;
 
 public class TargetFrameRate : MonoBehaviour {
-
 	void Awake () {
-	    // Its a dead simple app. There's no need for 120 fps
-	    // By default the vSyncCount is 2 (1/2 of max fps, ex. 120/2 = 60)
-	    
-	    QualitySettings.vSyncCount = PlayerPrefs.GetInt("vSyncRate", 2);
-	    Application.targetFrameRate =  PlayerPrefs.GetInt("fpsTarget", 0);
+		// Its a dead simple app. There's no need for 120 fps
+		// By default the vSyncCount is 2 (1/2 of max fps, ex. 120/2 = 60)
+
+		QualitySettings.vSyncCount = PlayerPrefs.GetInt("vSyncRate", 2);
+		// fpsTarget is saved as a dropdown value, e.g. 3 for 30fps
+		Application.targetFrameRate = PlayerPrefs.GetInt("fpsTarget", 0) * 10;
 	}
 }

--- a/Assets/Scripts/UI/MainMenu.cs
+++ b/Assets/Scripts/UI/MainMenu.cs
@@ -1,4 +1,4 @@
-﻿using TMPro;
+using TMPro;
 using UnityEngine;
 using UnityEngine.Serialization;
 using UnityEngine.UI;
@@ -24,38 +24,20 @@ public class MainMenu : MonoBehaviour {
   
   public void SetVSyncRatio(System.Int32 value)
   {
-    // Clear fpsTarget
-    PlayerPrefs.SetInt("fpsTarget", 0);
-    fpsTarget.value = 0;
-    Application.targetFrameRate = -1;
-		
-    if (value == 0)
-    {
-      SetFpsTarget(3);
-    }
-		
     PlayerPrefs.SetInt("vSyncRate", value);
-    vSyncRate.value = value;
-		
     QualitySettings.vSyncCount = value;
+
+    if (value != 0)
+      fpsTarget.value = 0;
   }
 
   public void SetFpsTarget(System.Int32 value)
   {
-    // Clear vSync Count
-    PlayerPrefs.SetInt("vSyncRate", 0);
-    vSyncRate.value = 0;
-    QualitySettings.vSyncCount = 0;
-		
-    if (value == 0)
-    {
-      SetVSyncRatio(2);
-    }
-		
     PlayerPrefs.SetInt("fpsTarget", value);
-    fpsTarget.value = value;
-		
     Application.targetFrameRate = value != 0 ? value * 10 : -1;
+
+    if (value != 0)
+      vSyncRate.value = 0;
   }
 
   void LateUpdate() {


### PR DESCRIPTION
This PR fixes the following issues:
- The game loading `fpsTarget` and directly setting it as the `Application.targetFrameRate`. Since `fpsTarget` is actually the value of the frame rate limit dropdown, it would result in the game setting the target frame rate to an unplayable value, like 3 or 6 (should be 30 or 60).
- `fpsTarget` and `vSyncRate` overwriting each other in their setter functions, resulting in seemingly no saving of those values, and them resetting on each restart/scene change.

Setting both the framerate and vsync targets to 0 is now also allowed, resulting in an unlocked framerate

> [!NOTE]
>  Please check if everything works properly (mainly on Windows and MacOS) before merging