### PR TITLE
Fix Missing Pin Names (UNNAMED PIN) [unreleased version]

### DIFF
--- a/Assets/Modules/Interaction System/Implementation/Pin/Display/PinDisplay.cs
+++ b/Assets/Modules/Interaction System/Implementation/Pin/Display/PinDisplay.cs
@@ -20,7 +20,7 @@ public class PinDisplay : MonoBehaviour
     {
         PinRenderer = GetComponent<Renderer>();
     }
-    
+
 
     private void OnDestroy()
     {
@@ -30,14 +30,14 @@ public class PinDisplay : MonoBehaviour
     private void Start()
     {
         InteractionPalette = ThemeManager.Palette.interactionPalette;
-        
+
         var Pin = GetComponent<PinEvent>();
         // Pin.OnStateChange += UpdateColor;
         Pin.MouseInteraction.MouseEntered += (_) => SelectionAppearance();
-        Pin.MouseInteraction.MouseExitted += (_) => NormalAppearance();
+        Pin.MouseInteraction.MouseExited += (_) => NormalAppearance();
         ScalingManager.i.OnScaleChange += UpdateScale;
-        
-        
+
+
         PinRenderer.material.color = InteractionPalette.PinDefaultColor;
         UpdateScale();
     }

--- a/Assets/Modules/Interaction System/Implementation/Pin/Display/PinNameDisplay.cs
+++ b/Assets/Modules/Interaction System/Implementation/Pin/Display/PinNameDisplay.cs
@@ -61,7 +61,8 @@ public class PinNameDisplay : MonoBehaviour
     //cambiare il metodo d accesso
     private void Start()
     {
-        UpdateScale();
+        // NameChanged() calls UpdateScale() automatically
+        NameChanged();
         ChipEditorOptions.instance.OnPinDisplayActionChange += SetMode;
     }
 

--- a/Assets/Modules/Interaction System/Implementation/Pin/Display/PinNameDisplay.cs
+++ b/Assets/Modules/Interaction System/Implementation/Pin/Display/PinNameDisplay.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics.Tracing;
 using Interaction.Signal;
 using TMPro;
@@ -35,7 +35,7 @@ public class PinNameDisplay : MonoBehaviour
 
         PinEvent = transform.parent.GetComponentInChildren<PinEvent>();
         PinEvent.MouseInteraction.MouseExitted += MouseExitHandler;
-        PinEvent.OnMOuseOver += OverHandler;
+        PinEvent.OnMouseOverAction += OverHandler;
 
 
         ScalingManager.i.OnScaleChange += UpdateScale;

--- a/Assets/Modules/Interaction System/Implementation/Pin/Display/PinNameDisplay.cs
+++ b/Assets/Modules/Interaction System/Implementation/Pin/Display/PinNameDisplay.cs
@@ -26,7 +26,7 @@ public class PinNameDisplay : MonoBehaviour
         var interaction = GetComponentInParent<SignalInteraction>();
         if (interaction)
         {
-            Interaction =interaction;
+            Interaction = interaction;
             IsInteraction = true;
             Interaction.OnPropertyChange += NameChanged;
         }
@@ -34,12 +34,12 @@ public class PinNameDisplay : MonoBehaviour
         pin = GetComponentInParent<Pin>();
 
         PinEvent = transform.parent.GetComponentInChildren<PinEvent>();
-        PinEvent.MouseInteraction.MouseExitted += MouseExitHandler;
+        PinEvent.MouseInteraction.MouseExited += MouseExitHandler;
         PinEvent.OnMouseOverAction += OverHandler;
 
 
         ScalingManager.i.OnScaleChange += UpdateScale;
-        SetMode( ChipEditorOptions.instance.ActiveMode);
+        SetMode(ChipEditorOptions.instance.ActiveMode);
     }
 
 

--- a/Assets/Modules/Interaction System/Implementation/Pin/PinEvent.cs
+++ b/Assets/Modules/Interaction System/Implementation/Pin/PinEvent.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 public class PinEvent : MonoBehaviour
 {
     public MouseInteraction<Pin> MouseInteraction;
-    public Action OnMOuseOver;
+    public Action OnMouseOverAction;
 
     private void Awake()
     {
@@ -24,6 +24,6 @@ public class PinEvent : MonoBehaviour
 
     private void OnMouseOver()
     {
-        OnMOuseOver?.Invoke();
+        OnMouseOverAction?.Invoke();
     }
 }

--- a/Assets/Modules/Interaction System/Implementation/Signal/ChipInterfaceEditor.cs
+++ b/Assets/Modules/Interaction System/Implementation/Signal/ChipInterfaceEditor.cs
@@ -87,7 +87,7 @@ public class ChipInterfaceEditor : MonoBehaviour
         ScalingManager.i.OnScaleChange += UpdateScale;
         CreateGroup.i.onGroupSizeSettingPressed += OnGroupSizeSettingPressed;
         InterfaceEvent.mouseInteraction.MouseEntered += (_) => ShowPreviewSignal(true);
-        InterfaceEvent.mouseInteraction.MouseExitted += (_) => ShowPreviewSignal(false);
+        InterfaceEvent.mouseInteraction.MouseExited += (_) => ShowPreviewSignal(false);
         InterfaceEvent.mouseInteraction.LeftMouseDown += (_) => SpawnSignal();
 
 

--- a/Assets/Modules/Interaction System/Implementation/Wire/Display/WireDisplay.cs
+++ b/Assets/Modules/Interaction System/Implementation/Wire/Display/WireDisplay.cs
@@ -58,7 +58,7 @@ public class WireDisplay : ThemeDisplay
             wire.RequestFocus();
             SelectAppearance();
         };
-        wireEventMouse.MouseInteraction.MouseExitted += (_) =>
+        wireEventMouse.MouseInteraction.MouseExited += (_) =>
         {
             wire.ReleaseFocus();
             NormalAppearance();

--- a/Assets/Plugin/Seb/SebInput/Internal/MouseInteractionListener.cs
+++ b/Assets/Plugin/Seb/SebInput/Internal/MouseInteractionListener.cs
@@ -9,7 +9,7 @@ namespace SebInput.Internal
 		// Called when mouse enters composite collider
 		public event System.Action MouseEntered;
 		// Called when mouse exits composite collider
-		public event System.Action MouseExitted;
+		public event System.Action MouseExited;
 
 		// Called when left mouse is pressed down over composite collider
 		public event System.Action LeftMouseDown;
@@ -37,7 +37,7 @@ namespace SebInput.Internal
 
 		public void OnMouseExit()
 		{
-			MouseExitted?.Invoke();
+			MouseExited?.Invoke();
 		}
 
 		public void OnMousePressDown(MouseEventSystem.MouseButton mouseButton)
@@ -52,7 +52,7 @@ namespace SebInput.Internal
 					break;
 			}
 		}
-		
+
 
 		public void OnClickCompleted(MouseEventSystem.MouseButton mouseButton)
 		{

--- a/Assets/Plugin/Seb/SebInput/MouseInteraction.cs
+++ b/Assets/Plugin/Seb/SebInput/MouseInteraction.cs
@@ -13,7 +13,7 @@ namespace SebInput
 		// Called when mouse enters composite collider
 		public event System.Action<T> MouseEntered;
 		// Called when mouse exits composite collider
-		public event System.Action<T> MouseExitted;
+		public event System.Action<T> MouseExited;
 
 		// Called when left mouse is pressed down over composite collider
 		public event System.Action<T> LeftMouseDown;
@@ -37,9 +37,9 @@ namespace SebInput
 		{
 			var listener = listenerTarget.AddComponent<MouseInteractionListener>();
 			Context = eventContext;
-			
+
 			listener.MouseEntered += () => { MouseIsOver = true; MouseEntered?.Invoke(eventContext); };
-			listener.MouseExitted += () => { MouseIsOver = false; MouseExitted?.Invoke(eventContext); };
+			listener.MouseExited += () => { MouseIsOver = false; MouseExited?.Invoke(eventContext); };
 			listener.LeftMouseDown += () => LeftMouseDown?.Invoke(eventContext);
 			listener.RightMouseDown += () => RightMouseDown?.Invoke(eventContext);
 			listener.LeftMouseReleased += () => LeftMouseReleased?.Invoke(eventContext);

--- a/Assets/Plugin/Seb/SebInput/MouseInteractionGroup.cs
+++ b/Assets/Plugin/Seb/SebInput/MouseInteractionGroup.cs
@@ -10,7 +10,7 @@ namespace SebInput
 	{
 
 		public event System.Action<T> MouseEntered;
-		public event System.Action<T> MouseExitted;
+		public event System.Action<T> MouseExited;
 
 		public event System.Action<T> LeftMouseDown;
 		public event System.Action<T> RightMouseDown;
@@ -23,7 +23,7 @@ namespace SebInput
 		public void AddInteractionToGroup(MouseInteraction<T> interaction)
 		{
 			interaction.MouseEntered += (e) => MouseEntered?.Invoke(e);
-			interaction.MouseExitted += (e) => MouseExitted?.Invoke(e);
+			interaction.MouseExited += (e) => MouseExited?.Invoke(e);
 			interaction.LeftMouseDown += (e) => LeftMouseDown?.Invoke(e);
 			interaction.RightMouseDown += (e) => RightMouseDown?.Invoke(e);
 			interaction.LeftMouseReleased += (e) => LeftMouseReleased?.Invoke(e);


### PR DESCRIPTION
Fixes an issue on the main branch (unreleased version) where the pin names are not updated, resulting in them being displayed as "UNNAMED PIN".

Also renamed:
- `MouseExitted` -> `MouseExited`
- `OnMOuseOver` -> `OnMouseOverAction`